### PR TITLE
System.X509.Unix (defaultSystemPaths): Support NetBSD

### DIFF
--- a/x509-system/System/X509/Unix.hs
+++ b/x509-system/System/X509/Unix.hs
@@ -30,6 +30,7 @@ defaultSystemPaths =
     [ "/etc/ssl/certs/"                 -- linux
     , "/system/etc/security/cacerts/"   -- android
     , "/usr/local/share/certs/"         -- freebsd
+    , "/etc/openssl/certs/"             -- netbsd
     , "/etc/ssl/cert.pem"               -- openbsd
     ]
 


### PR DESCRIPTION
Add a system default certificate path for NetBSD.