### PR TITLE
Fix dependency on crypton-x509 test

### DIFF
--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -54,8 +54,8 @@ Test-Suite test-x509
                    , tasty-quickcheck
                    , hourglass
                    , asn1-types
-                   , x509
                    , crypton
+                   , crypton-x509
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
 
 source-repository head


### PR DESCRIPTION
Unless I am misunderstanding the purpose of the test, it looks like the `crypton-x509` test suite requires `x509` instead of `crypton-x509`, which, when compiling, fails because the appropriate Arbitrary instance is not defined.  I am guessing this is not intentional because we define Arbitrary instances for the crypton-x509 types of the same name, but do not use them AFAICT. This seems to only be an issue for `crypton-x509` and not the others.