### PR TITLE
data-default-class -> data-default

### DIFF
--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -34,7 +34,7 @@ module Data.X509.Validation
 
 import Control.Applicative
 import Control.Monad (when)
-import Data.Default.Class
+import Data.Default
 import Data.ASN1.Types
 import Data.Char (toLower)
 import Data.X509

--- a/x509-validation/Data/X509/Validation/Cache.hs
+++ b/x509-validation/Data/X509/Validation/Cache.hs
@@ -22,7 +22,7 @@ module Data.X509.Validation.Cache
     ) where
 
 import Control.Concurrent
-import Data.Default.Class
+import Data.Default
 import Data.X509
 import Data.X509.Validation.Types
 import Data.X509.Validation.Fingerprint

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -10,7 +10,7 @@ import qualified Crypto.PubKey.DSA        as DSA
 import qualified Crypto.PubKey.ECC.Types  as ECC
 import qualified Crypto.PubKey.RSA.PSS    as PSS
 
-import Data.Default.Class
+import Data.Default
 import Data.Monoid
 import Data.String (fromString)
 import Data.X509

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -21,7 +21,7 @@ Library
                    , mtl
                    , containers
                    , hourglass
-                   , data-default-class
+                   , data-default >= 0.8
                    , pem >= 0.1
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
@@ -44,7 +44,7 @@ Test-Suite test-x509-validation
   Build-Depends:     base >= 3 && < 5
                    , bytestring
                    , memory
-                   , data-default-class
+                   , data-default
                    , tasty
                    , tasty-hunit
                    , hourglass


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

See: https://github.com/commercialhaskell/stackage/issues/7545