### PR TITLE
Load  certificates in the order in which they appear

### DIFF
--- a/x509-store/Data/X509/Memory.hs
+++ b/x509-store/Data/X509/Memory.hs
@@ -33,12 +33,9 @@ readSignedObjectFromMemory
     :: (ASN1Object a, Eq a, Show a)
     => B.ByteString
     -> [X509.SignedExact a]
-readSignedObjectFromMemory = either (const []) (foldl pemToSigned []) . pemParseBS
+readSignedObjectFromMemory = either (const []) decodePems . pemParseBS
   where
-    pemToSigned acc pem =
-        case X509.decodeSignedObject $ pemContent pem of
-            Left _ -> acc
-            Right obj -> obj : acc
+    decodePems pems = [ obj | pem <- pems, Right obj <- [X509.decodeSignedObject $ pemContent pem] ]
 
 pemToKey :: [Maybe X509.PrivKey] -> PEM -> [Maybe X509.PrivKey]
 pemToKey acc pem =


### PR DESCRIPTION
See https://github.com/haskell-tls/hs-certificate/pull/57 .

Perhaps dynamically constructing the chain as suggested in one of the comments in https://github.com/haskell-tls/hs-certificate/issues/31 is the proper solution, but this at least fixes this surprising behaviour, where the certificates are read in reverse (took us a long time to figure out the issue).