### PR TITLE
Don't parse in memory pem files in reverse order

### DIFF
--- a/x509-store/Data/X509/File.hs
+++ b/x509-store/Data/X509/File.hs
@@ -40,4 +40,4 @@ readSignedObject filepath = decodePEMs <$> readPEMs filepath
 
 -- | return all the private keys that were successfully read from a file.
 readKeyFile :: FilePath -> IO [X509.PrivKey]
-readKeyFile path = catMaybes . foldl pemToKey [] <$> readPEMs path
+readKeyFile path = catMaybes . foldr pemToKey [] <$> readPEMs path

--- a/x509-store/Data/X509/Memory.hs
+++ b/x509-store/Data/X509/Memory.hs
@@ -27,21 +27,21 @@ import qualified Data.X509 as X509
 import Data.X509.EC as X509
 
 readKeyFileFromMemory :: B.ByteString -> [X509.PrivKey]
-readKeyFileFromMemory = either (const []) (catMaybes . foldl pemToKey []) . pemParseBS
+readKeyFileFromMemory = either (const []) (catMaybes . foldr pemToKey []) . pemParseBS
 
 readSignedObjectFromMemory
     :: (ASN1Object a, Eq a, Show a)
     => B.ByteString
     -> [X509.SignedExact a]
-readSignedObjectFromMemory = either (const []) (foldl pemToSigned []) . pemParseBS
+readSignedObjectFromMemory = either (const []) (foldr pemToSigned []) . pemParseBS
   where
-    pemToSigned acc pem =
+    pemToSigned pem acc =
         case X509.decodeSignedObject $ pemContent pem of
             Left _ -> acc
             Right obj -> obj : acc
 
-pemToKey :: [Maybe X509.PrivKey] -> PEM -> [Maybe X509.PrivKey]
-pemToKey acc pem =
+pemToKey :: PEM -> [Maybe X509.PrivKey] -> [Maybe X509.PrivKey]
+pemToKey pem acc =
     case decodeASN1' BER (pemContent pem) of
         Left _ -> acc
         Right asn1 ->

--- a/x509-util/src/Certificate.hs
+++ b/x509-util/src/Certificate.hs
@@ -382,7 +382,7 @@ doKeyMain files = do
     pems <- readPEMFile (head files)
     forM_ pems $ \pem -> do
         let content = either (error . show) id $ decodeASN1' BER (pemContent pem)
-            privkey = catMaybes $ pemToKey [] pem
+            privkey = catMaybes $ pemToKey pem []
         case privkey of
             [X509.PrivKeyRSA k] ->
                 putStrLn "RSA KEY" >> putStrLn (showRSAKey k)


### PR DESCRIPTION
Downstream consumers of readSignedObjectFromMemory rely on the order of certificates parsed from a pem file. Return them in the same order that they are in memory. This matches the results of readSignedObject.

Change the parsing of keys to be the same order as they are on the disk as well. The overwhelming number of key files will have one key in them. For those, this will be a no-op. In the case that there are more keys, the downstream consumer is almost certainly expecting them in the order they are on disk.