### PR TITLE
Swap `crypton-pem` for existing unmaintained `pem` dependency

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,8 @@ packages:
 - x509-validation
 - x509-util
 
+extra-deps:
+- crypton-pem-0.3.0
+
 nix:
   pure: false

--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -21,7 +21,7 @@ Library
                    , containers
                    , directory
                    , filepath
-                   , pem >= 0.1 && < 0.3
+                   , crypton-pem >= 0.2.4 && < 0.4
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
                    , crypton

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -22,7 +22,7 @@ Library
                    , directory
                    , filepath
                    , process
-                   , pem >= 0.1 && < 0.3
+                   , crypton-pem >= 0.2.4 && < 0.4
                    , crypton-x509 >= 1.6
                    , crypton-x509-store >= 1.6.2
   Exposed-modules:   System.X509

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -26,7 +26,7 @@ Executable           crypton-x509-util
                    , crypton-x509-validation >= 1.6.3
                    , asn1-types >= 0.3
                    , asn1-encoding
-                   , pem
+                   , crypton-pem
                    , directory
                    , hourglass
                    , memory

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -22,7 +22,7 @@ Library
                    , containers
                    , hourglass
                    , data-default
-                   , pem >= 0.1
+                   , crypton-pem >= 0.2.4
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
                    , crypton-x509 >= 1.7.5

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -21,7 +21,7 @@ Library
                    , transformers >= 0.4
                    , containers
                    , hourglass
-                   , pem >= 0.1
+                   , crypton-pem >= 0.2.4
                    , asn1-types >= 0.3.1 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
                    , asn1-parse >= 0.9.3 && < 0.10


### PR DESCRIPTION
See:
* https://github.com/kazu-yamamoto/crypton-connection/issues/9
* https://discourse.haskell.org/t/pem-forked-as-crypton-pem/12450
* https://github.com/mpilgrem/crypton-pem

`crypton-pem >= 0.3.0` will also eliminate the indirect dependency of these packages on unmaintained `basement`.

Tested by building the project locally with `stack build` and the revised Stack project-level configuration file.