### PR TITLE
Depend on `time-hourglass` (not `hourglass`) and `crypton-asn1-*` (not `asn1-*`)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-
-resolver: lts-23.8
+snapshot: lts-23.27 # GHC 9.8.4
 
 packages:
 - x509
@@ -7,6 +6,12 @@ packages:
 - x509-system
 - x509-validation
 - x509-util
+
+extra-deps:
+- crypton-asn1-encoding-0.10.0@sha256:45494a1723a047a815d0d620481c1028dca28a4ea5cf2554868687da90753961,2497
+- crypton-asn1-parse-0.10.0@sha256:4a2cfc4980957d1a279ef69137ee5f665c247ccd8bb962812d5b071d543893fb,1359
+- crypton-asn1-types-0.4.1@sha256:02f3ec473011b3da92f7bf738bea19cadf88a6470b25a6cb5042216c7549c912,1326
+- time-hourglass-0.3.0@sha256:ee02356fe24919ec43ae17fc0007398c2fd0bbe822833b2d7a9c849537b90580,3114
 
 nix:
   pure: false

--- a/x509-store/ChangeLog.md
+++ b/x509-store/ChangeLog.md
@@ -1,0 +1,8 @@
+# ChangeLog for crypton-x509-store
+
+## 2025-08-02 v1.7.0
+
+- Depend indirectly on package `time-hourglass`, rather than `hourglass`. Date
+  and time-related types and classes are now those from the former package.
+- Depend on package `crypton-asn1-types >= 0.4.1` rather than `asn1-types`.
+  ASN.1-related types and classes are now those from the former package.

--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509-store
-version:             1.6.11
+version:             1.7.0
 Description:         X.509 collection accessing and storing methods for certificate, crl, exception list
 License:             BSD3
 License-file:        LICENSE
@@ -22,10 +22,10 @@ Library
                    , directory
                    , filepath
                    , pem >= 0.1 && < 0.3
-                   , asn1-types >= 0.3 && < 0.4
-                   , asn1-encoding >= 0.9 && < 0.10
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
+                   , crypton-asn1-encoding >= 0.10.0 && < 0.11
                    , crypton
-                   , crypton-x509 >= 1.7.2
+                   , crypton-x509 >= 1.8.0
   Exposed-modules:   Data.X509.CertificateStore
                      Data.X509.File
                      Data.X509.Memory
@@ -40,7 +40,7 @@ Test-Suite test-x509-store
                    , bytestring
                    , tasty
                    , tasty-hunit
-                   , crypton-x509
+                   , crypton-x509 >= 1.8.0
                    , crypton-x509-store
   ghc-options:       -Wall
 

--- a/x509-system/ChangeLog.md
+++ b/x509-system/ChangeLog.md
@@ -1,0 +1,9 @@
+# ChangeLog for crypton-x509-system
+
+## 2025-08-02 v1.7.0
+
+- Depend indirectly on package `time-hourglass`, rather than `hourglass`. Date
+  and time-related types and classes are now those from the former package.
+- Depend indirectly on package `crypton-asn1-types >= 0.4.1` rather
+  than `asn1-types`. ASN.1-related types and classes are now those from the
+  former package.

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509-system
-version:             1.6.7
+version:             1.7.0
 Synopsis:            Handle per-operating-system X.509 accessors and storage
 Description:         System X.509 handling for accessing operating system dependents store and other storage methods
 License:             BSD3
@@ -23,8 +23,8 @@ Library
                    , filepath
                    , process
                    , pem >= 0.1 && < 0.3
-                   , crypton-x509 >= 1.6
-                   , crypton-x509-store >= 1.6.2
+                   , crypton-x509 >= 1.8
+                   , crypton-x509-store >= 1.7.0
   Exposed-modules:   System.X509
                      System.X509.Unix
                      System.X509.MacOS

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509-util
-version:             1.6.6
+version:             1.6.6.1
 Description:         utility to parse, show, validate, sign and produce X509 certificates and chain.
 License:             BSD3
 License-file:        LICENSE
@@ -20,15 +20,15 @@ Executable           crypton-x509-util
   Buildable:         True
   Build-depends:     base >= 3 && < 5
                    , bytestring
-                   , crypton-x509 >= 1.7.1
-                   , crypton-x509-store
-                   , crypton-x509-system
-                   , crypton-x509-validation >= 1.6.3
-                   , asn1-types >= 0.3
-                   , asn1-encoding
+                   , crypton-x509 >= 1.8.0
+                   , crypton-x509-store >= 1.7.0
+                   , crypton-x509-system >= 1.7.0
+                   , crypton-x509-validation >= 1.7.0
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
+                   , crypton-asn1-encoding >= 0.10.0 && < 0.11
                    , pem
                    , directory
-                   , hourglass
+                   , time-hourglass
                    , memory
                    , crypton
 

--- a/x509-validation/ChangeLog.md
+++ b/x509-validation/ChangeLog.md
@@ -1,12 +1,8 @@
-# ChangeLog for crypton-x509
+# ChangeLog for crypton-x509-validation
 
-## 2025-08-02 v1.8.0
+## 2025-08-02 v1.7.0
 
 - Depend on package `time-hourglass`, rather than `hourglass`. Date and
   time-related types and classes are now those from the former package.
 - Depend on package `crypton-asn1-types >= 0.4.1` rather than `asn1-types`.
   ASN.1-related types and classes are now those from the former package.
-
-## 2022-05-31 v1.7.7
-
-- Bump requirements to GHC 7.8 and transformers 0.4 series [#130](https://github.com/haskell-tls/hs-certificate/pull/130)

--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -55,7 +55,7 @@ import Data.X509.Validation.Cache
 import Data.X509.Validation.Fingerprint
 import Data.X509.Validation.Signature
 import Data.X509.Validation.Types
-import System.Hourglass
+import Time.System
 import Text.Read (readMaybe)
 
 -- | Possible reason of certificate and chain failure.

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -20,7 +20,7 @@ import Data.X509.Validation
 import qualified Data.ByteString as BS
 
 import Data.Hourglass
-import System.Hourglass
+import Time.System
 
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509-validation
-version:             1.6.14
+version:             1.7.0
 Description:         X.509 Certificate and CRL validation. please see README
 License:             BSD3
 License-file:        LICENSE
@@ -20,13 +20,13 @@ Library
                    , memory
                    , mtl
                    , containers
-                   , hourglass
+                   , time-hourglass
                    , data-default
                    , pem >= 0.1
-                   , asn1-types >= 0.3 && < 0.4
-                   , asn1-encoding >= 0.9 && < 0.10
-                   , crypton-x509 >= 1.7.5
-                   , crypton-x509-store >= 1.6
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
+                   , crypton-asn1-encoding >= 0.10.0 && < 0.11
+                   , crypton-x509 >= 1.8.0
+                   , crypton-x509-store >= 1.7.0
                    , crypton >= 0.24
                    , iproute >= 1.2.2
   Exposed-modules:   Data.X509.Validation
@@ -48,11 +48,11 @@ Test-Suite test-x509-validation
                    , data-default
                    , tasty
                    , tasty-hunit
-                   , hourglass
-                   , asn1-types
-                   , asn1-encoding
-                   , crypton-x509 >= 1.7.1
-                   , crypton-x509-store
+                   , time-hourglass
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
+                   , crypton-asn1-encoding >= 0.10.0 && < 0.11
+                   , crypton-x509 >= 1.8.0
+                   , crypton-x509-store >= 1.7.0
                    , crypton-x509-validation
                    , crypton
   ghc-options:       -Wall

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509
-version:             1.7.7
+version:             1.8.0
 Description:         X509 reader and writer. please see README
 License:             BSD3
 License-file:        LICENSE
@@ -20,11 +20,11 @@ Library
                    , memory
                    , transformers >= 0.4
                    , containers
-                   , hourglass
+                   , time-hourglass
                    , pem >= 0.1
-                   , asn1-types >= 0.3.1 && < 0.4
-                   , asn1-encoding >= 0.9 && < 0.10
-                   , asn1-parse >= 0.9.3 && < 0.10
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
+                   , crypton-asn1-encoding >= 0.10.0 && < 0.11
+                   , crypton-asn1-parse >= 0.10.0 && < 0.11
                    , crypton >= 0.24
   Exposed-modules:   Data.X509
                      Data.X509.EC
@@ -52,8 +52,8 @@ Test-Suite test-x509
                    , mtl
                    , tasty
                    , tasty-quickcheck
-                   , hourglass
-                   , asn1-types
+                   , time-hourglass
+                   , crypton-asn1-types >= 0.4.1 && < 0.5
                    , crypton-x509
                    , crypton
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures


### PR DESCRIPTION
Packages `time-hourglass` and `crypton-asn1-*` are maintained, unlike `hourglass` and `asn1-*`.

See:
* https://discourse.haskell.org/t/asn1-forked-as-crypton-asn1/12458
* https://discourse.haskell.org/t/hourglass-forked-as-time-hourglass/12520

Raised independently of:
* #16

but if one is merged, the other will need to be rebased.

Also import `Time.System` (replaces deprecated 'System.Hourglass').

Requires major version bump. Also adds upper bounds.

Also updates, or adds, change logs for user-facing effects.

Also bumps `stack.yaml` to latest Stackage LTS Haskell for GHC 9.8.4