### PR TITLE
Unix defaultSystemPaths: add new Fedora default cert filepath

### DIFF
--- a/x509-system/System/X509/Unix.hs
+++ b/x509-system/System/X509/Unix.hs
@@ -26,7 +26,8 @@ import Data.Monoid (mconcat)
 
 defaultSystemPaths :: [FilePath]
 defaultSystemPaths =
-    [ "/etc/ssl/certs/" -- linux
+    [ "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" -- fedora
+    , "/etc/ssl/certs/" -- linux
     , "/system/etc/security/cacerts/" -- android
     , "/usr/local/share/certs/" -- freebsd
     , "/etc/ssl/cert.pem" -- openbsd


### PR DESCRIPTION
closes #17 

See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile for more background