### PR TITLE
crypton-x509-store: Make it buildable with ghc-9.4 and ghc-9.2

### DIFF
--- a/x509-store/Data/X509/File.hs
+++ b/x509-store/Data/X509/File.hs
@@ -16,7 +16,7 @@ import Data.Maybe
 import Data.PEM (PEM, pemContent, pemName, pemParseLBS)
 import qualified Data.X509 as X509
 import Data.X509.Memory (pemToKey)
-#if !defined(mingw32_HOST_OS)
+#if !defined(mingw32_HOST_OS) && (MIN_VERSION_unix(2,8,0))
 import System.Posix.IO
 #endif
 
@@ -28,7 +28,7 @@ instance Exception PEMError where
 
 readPEMs :: FilePath -> IO [PEM]
 readPEMs filepath = do
-#if defined(mingw32_HOST_OS)
+#if defined(mingw32_HOST_OS) || !(MIN_VERSION_unix(2,8,0))
     content <- L.readFile filepath
 #else
     fd <- openFd filepath ReadOnly defaultFileFlags{cloexec = True}


### PR DESCRIPTION
Building fails on ghc-9.4 and ghc-9.2.

https://github.com/khibino/dnsext/actions/runs/18780441938/job/53584990066