### PR TITLE
x509-system: prefer OpenSSL env vars: SSL_CERT_FILE and SSL_CERT_DIR

### DIFF
--- a/x509-system/System/X509/Common.hs
+++ b/x509-system/System/X509/Common.hs
@@ -1,0 +1,26 @@
+module System.X509.Common
+  ( maybeSSLCertEnvOr
+  )
+where
+
+import Data.Foldable (asum)
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Monoid (mconcat)
+import Data.X509.CertificateStore
+import System.Environment (lookupEnv)
+
+getOpenSslEnvs :: IO (Maybe String)
+getOpenSslEnvs =
+  asum
+    <$> traverse
+      lookupEnv
+      [ "SSL_CERT_FILE",
+        "SSL_CERT_DIR"
+      ]
+
+maybeSSLCertEnvOr :: IO CertificateStore -> IO CertificateStore
+maybeSSLCertEnvOr defaultStore = do
+  overrideCertPaths <- getOpenSslEnvs
+  case overrideCertPaths of
+    Nothing -> defaultStore
+    Just certPath -> fromMaybe mempty <$> (readCertificateStore certPath)

--- a/x509-system/System/X509/MacOS.hs
+++ b/x509-system/System/X509/MacOS.hs
@@ -10,6 +10,7 @@ import System.Process
 
 import Data.X509
 import Data.X509.CertificateStore
+import System.X509.Common (maybeSSLCertEnvOr)
 
 rootCAKeyChain :: FilePath
 rootCAKeyChain = "/System/Library/Keychains/SystemRootCertificates.keychain"
@@ -33,4 +34,4 @@ listInKeyChains keyChains = do
     return targets
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = makeCertificateStore <$> listInKeyChains [rootCAKeyChain, systemKeyChain]
+getSystemCertificateStore = maybeSSLCertEnvOr (makeCertificateStore <$> listInKeyChains [rootCAKeyChain, systemKeyChain])

--- a/x509-system/System/X509/Unix.hs
+++ b/x509-system/System/X509/Unix.hs
@@ -17,6 +17,7 @@ module System.X509.Unix (
 
 import Data.X509.CertificateStore
 import System.Environment (getEnv)
+import System.X509.Common (maybeSSLCertEnvOr)
 
 import Control.Applicative ((<$>))
 import qualified Control.Exception as E
@@ -36,7 +37,7 @@ envPathOverride :: String
 envPathOverride = "SYSTEM_CERTIFICATE_PATH"
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = mconcat . catMaybes <$> (getSystemPaths >>= mapM readCertificateStore)
+getSystemCertificateStore = maybeSSLCertEnvOr (mconcat . catMaybes <$> (getSystemPaths >>= mapM readCertificateStore))
 
 getSystemPaths :: IO [FilePath]
 getSystemPaths = E.catch ((: []) <$> getEnv envPathOverride) inDefault

--- a/x509-system/System/X509/Win32.hs
+++ b/x509-system/System/X509/Win32.hs
@@ -21,6 +21,7 @@ import Data.X509
 import Data.X509.CertificateStore
 
 import System.Win32.Types
+import System.X509.Common (maybeSSLCertEnvOr)
 
 type HCertStore = Ptr Word8
 type PCCERT_Context = Ptr Word8
@@ -54,7 +55,7 @@ certFromContext cctx = do
     cbCertEncodedPos = pbCertEncodedPos + sizeOf (undefined :: Ptr (Ptr BYTE))
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = do
+getSystemCertificateStore = maybeSSLCertEnvOr $ do
     store <- certOpenSystemStore
     when (store == nullPtr) $ error "no store"
     certs <- loop store nullPtr

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -26,6 +26,7 @@ Library
                    , crypton-x509 >= 1.6
                    , crypton-x509-store >= 1.6.2
   Exposed-modules:   System.X509
+                     System.X509.Common
                      System.X509.Unix
                      System.X509.MacOS
   ghc-options:       -Wall


### PR DESCRIPTION
Trivial port of haskell-tls/hs-certificate#127 by @meghfossa which addresses #20 (haskell-tls/hs-certificate#118)

(well it doesn't actually drop `SYSTEM_CERTIFICATE_PATH`, which is still needed for back compatibility I presume?)

Below is the original PR text:
----

# Overview

This PR modifies System.X509's `getSystemCertificateStore` method, to favour OpenSSL environment variables (as used by git, curl, etc) namely:

- `SSL_CERT_FILE`
- `SSL_CERT_DIR`

If `SSL_CERT_FILE` or `SSL_CERT_DIR` values do not exist, previously implemented certificationStore is yielded.

# Order of precedence:

- `SSL_CERT_FILE` (OpenSSL conventional env name)
- `SSL_CERT_DIR` (OpenSSL conventional env name)
- `SYSTEM_CERTIFICATE_PATH` (Unix Only - Existing implementation)

# To-do

- [ ] Regression Test on Linux
- [ ] Regression Test on Windows
- [ ] Regression Test on OSX

# Reference

https://github.com/haskell-tls/hs-certificate/issues/118
[Open SSL CTX Load](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html)