### PR TITLE
Omit AlgorithmIdentifier parameters for ECDSA and DSA signatures

### DIFF
--- a/crypton-x509/Data/X509/AlgorithmIdentifier.hs
+++ b/crypton-x509/Data/X509/AlgorithmIdentifier.hs
@@ -192,4 +192,10 @@ instance ASN1Object SignatureALG where
             : End Sequence
             : xs
     toASN1 signatureAlg@(SignatureALG_IntrinsicHash _) = \xs -> Start Sequence : OID (sigOID signatureAlg) : End Sequence : xs
+    -- ECDSA: "the encoding MUST omit the parameters field"
+    -- (RFC 5758 3.2, RFC 3279 2.2.3)
+    toASN1 signatureAlg@(SignatureALG _ PubKeyALG_EC) = \xs -> Start Sequence : OID (sigOID signatureAlg) : End Sequence : xs
+    -- DSA: "the encoding SHALL omit the parameters field"
+    -- (RFC 5758 3.1, RFC 3279 2.2.2)
+    toASN1 signatureAlg@(SignatureALG _ PubKeyALG_DSA) = \xs -> Start Sequence : OID (sigOID signatureAlg) : End Sequence : xs
     toASN1 signatureAlg = \xs -> Start Sequence : OID (sigOID signatureAlg) : Null : End Sequence : xs

--- a/crypton-x509/Tests/Tests.hs
+++ b/crypton-x509/Tests/Tests.hs
@@ -251,6 +251,18 @@ property_extension_id e = case extDecode (extEncode e) of
         | v == e -> True
         | otherwise -> error ("expected " ++ show e ++ " got: " ++ show v)
 
+-- Per-family AlgorithmIdentifier parameters contract:
+-- ECDSA (RFC 5758 3.2, RFC 3279 2.2.3) and DSA (RFC 5758 3.1, RFC 3279
+-- 2.2.2) omit the parameters field; RSA PKCS#1 v1.5 encodes an ASN.1
+-- NULL (RFC 3279 2.2.1); EdDSA omits the field (RFC 8410 3).
+property_sig_alg_parameters :: SignatureALG -> Bool
+property_sig_alg_parameters alg@(SignatureALG _ pub)
+    | pub == PubKeyALG_EC || pub == PubKeyALG_DSA = Null `notElem` toASN1 alg []
+    | pub == PubKeyALG_RSA = Null `elem` toASN1 alg []
+property_sig_alg_parameters alg@(SignatureALG_IntrinsicHash _) =
+    Null `notElem` toASN1 alg []
+property_sig_alg_parameters _ = True
+
 main =
     defaultMain $
         testGroup
@@ -268,6 +280,12 @@ main =
                     , testProperty
                         "extended-key-usage"
                         (property_extension_id :: ExtExtendedKeyUsage -> Bool)
+                    ]
+                , testGroup
+                    "signature-alg-parameters"
+                    [ testProperty
+                        "per-family"
+                        property_sig_alg_parameters
                     ]
                 , testProperty
                     "extensions"


### PR DESCRIPTION

`AlgorithmIdentifier` for ECDSA and DSA signatures included an explicit ASN.1 NULL in the `parameters` field. RFC 5758 ([Sections 3.1](https://datatracker.ietf.org/doc/html/rfc5758#section-3.1) and [Section 3.2](https://datatracker.ietf.org/doc/html/rfc5758#section-3.2)) and RFC 3279 ([Sections 2.2.2](https://datatracker.ietf.org/doc/html/rfc3279#section-2.2.2) and [Section 2.2.3](https://datatracker.ietf.org/doc/html/rfc3279#section-2.2.3)) require the encoding to omit the field. The other algorithm families are unaffected: RSA PKCS#1 v1.5 (NULL), RSASSA-PSS (structured parameters) and EdDSA (absent) already followed their respective requirements. This change affects encoding only; decoding already accepts both forms, so round-tripping and reading of existing data are unaffected.

Found while preparing the RFC 5755 attribute certificate support discussed in #28; this fix is useful independently of that work.

## Details

ASN.1:

```
AlgorithmIdentifier ::= SEQUENCE {
    algorithm   OBJECT IDENTIFIER,
    parameters  ANY DEFINED BY algorithm OPTIONAL }
```

The requirement for `parameters` differs per algorithm family:

| Algorithm | Requirement | Reference |
|-----------|-------------|-----------|
| RSA (PKCS#1 v1.5) | "the parameters component of that type SHALL be the ASN.1 type NULL" | RFC 3279, Section 2.2.1 |
| RSASSA-PSS | "The parameters MUST be present when used in the algorithm identifier associated with a signature value" (RSASSA-PSS-params) | RFC 4055, Section 3.1 |
| ECDSA | "the encoding MUST omit the parameters field" | RFC 5758, Section 3.2; RFC 3279, Section 2.2.3 |
| DSA | "the encoding SHALL omit the parameters field" | RFC 5758, Section 3.1; RFC 3279, Section 2.2.2 |
| EdDSA (Ed25519/Ed448) | "For all of the OIDs, the parameters MUST be absent" | RFC 8410, Section 3 |

RSASSA-PSS and EdDSA already had dedicated cases in `toASN1` (a structured RSASSA-PSS-params value and an omitted field, respectively). ECDSA and DSA had no dedicated case and fell through to the catch-all, which emits NULL — correct only for RSA PKCS#1 v1.5. (`SignatureALG_Unknown` keeps the previous NULL encoding, since the correct form cannot be known for an unrecognized OID.) On the wire, for ecdsa-with-SHA256:

```
before:  30 0C 06 08 2A 86 48 CE 3D 04 03 02 05 00   SEQUENCE { OID, NULL }
after:   30 0A 06 08 2A 86 48 CE 3D 04 03 02         SEQUENCE { OID }
```

OpenSSL omits the field. To reproduce (output below from OpenSSL 3.6.2 on macOS 26.5/arm64), generate an ECDSA certificate and inspect its ASN.1 structure:

```console
$ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
    -keyout key.pem -out cert.pem -days 1 -subj "/CN=ecdsa-demo"
$ openssl asn1parse -in cert.pem
    0:d=0  hl=4 l= 383 cons: SEQUENCE
    4:d=1  hl=4 l= 293 cons: SEQUENCE
...
   35:d=2  hl=2 l=  10 cons: SEQUENCE
   37:d=3  hl=2 l=   8 prim: OBJECT            :ecdsa-with-SHA256
   47:d=2  hl=2 l=  21 cons: SEQUENCE
...
  301:d=1  hl=2 l=  10 cons: SEQUENCE
  303:d=2  hl=2 l=   8 prim: OBJECT            :ecdsa-with-SHA256
  313:d=1  hl=2 l=  72 prim: BIT STRING
```

Both AlgorithmIdentifier occurrences — `tbsCertificate.signature` at offset 35 and the outer `signatureAlgorithm` at offset 301 — are 10-byte SEQUENCEs containing only the 8-byte OID, matching the "after" encoding above (`30 0A ...`). With a NULL they would be 12 bytes (`30 0C ...`).

Note that the exact offsets and the signature BIT STRING length vary between runs: the ECDSA signature value is a DER SEQUENCE of two INTEGERs (r, s), and DER prepends a 0x00 pad byte to an INTEGER whose most significant bit is set, so for P-256 each of r and s occupies 32 or 33 bytes depending on the randomly generated signature. The AlgorithmIdentifier SEQUENCEs, by contrast, are always exactly 10 bytes.

The same holds for DSA:

```console
$ openssl dsaparam -out dsap.pem 2048
$ openssl req -x509 -newkey dsa:dsap.pem -nodes -keyout key.pem -out cert.pem \
    -days 1 -subj "/CN=dsa-demo" -sha256
$ openssl asn1parse -in cert.pem
...
   35:d=2  hl=2 l=  11 cons: SEQUENCE
   37:d=3  hl=2 l=   9 prim: OBJECT            :dsa_with_SHA256
...
 1045:d=1  hl=2 l=  11 cons: SEQUENCE
 1047:d=2  hl=2 l=   9 prim: OBJECT            :dsa_with_SHA256
 1058:d=1  hl=2 l=  63 prim: BIT STRING
```

Both AlgorithmIdentifier SEQUENCEs are 11 bytes — the 9-byte OID of dsa-with-SHA256 alone, with no NULL.

Because the same structure appears inside `tbsCertificate.signature` (offset 35 in the asn1parse output above), the non-conformant form is part of the signed bytes.

`fromASN1` already accepts both the absent and the NULL form, so certificates written by previous releases still decode. EdDSA (`SignatureALG_IntrinsicHash`) was already encoded without parameters; this change extends the same treatment to ECDSA and DSA.

## Testing

- New QuickCheck property pinning the per-family contract: ECDSA/DSA encodings contain no NULL (fails before this change), RSA PKCS#1 v1.5 still contains NULL, and EdDSA still omits the field (regression guards).
- All existing tests pass (`cabal test` for crypton-x509 and crypton-x509-validation).
- Formatted with the repository's `fourmolu.yaml` (no diff under `fourmolu --mode check`).
