### PR TITLE
Encode GeneralName directoryName with a constructed [4] tag

### DIFF
--- a/crypton-x509/Data/X509/Ext.hs
+++ b/crypton-x509/Data/X509/Ext.hs
@@ -334,6 +334,18 @@ getAddr = do
         case n of
             (Other Context 1 b) -> return $ AltNameRFC822 $ BC.unpack b
             (Other Context 2 b) -> return $ AltNameDNS $ BC.unpack b
+            -- RFC 5280 4.2.1.6: directoryName [4] is EXPLICIT (constructed)
+            -- because Name is a CHOICE
+            (Start (Container Context 4)) -> do
+                dn <- getObject
+                n' <- getNext
+                case n' of
+                    End (Container Context 4) -> return $ AltNameDN dn
+                    _ ->
+                        throwParseError
+                            ("GeneralNames: expecting end of directoryName, got " ++ show n')
+            -- primitive [4] with nested DER, as emitted by crypton-x509
+            -- 1.9.1; accepted for backward compatibility
             (Other Context 4 b) -> case decodeASN1' DER b of
                 Left e1 -> throwParseError $ show e1
                 Right as -> case runParseASN1 getObject as of
@@ -353,7 +365,8 @@ encodeGeneralNames names =
 encodeAltName :: AltName -> [ASN1]
 encodeAltName (AltNameRFC822 n) = [Other Context 1 $ BC.pack n]
 encodeAltName (AltNameDNS n) = [Other Context 2 $ BC.pack n]
-encodeAltName (AltNameDN dn) = [Other Context 4 $ encodeASN1' DER $ toASN1 dn []]
+encodeAltName (AltNameDN dn) =
+    Start (Container Context 4) : toASN1 dn [End (Container Context 4)]
 encodeAltName (AltNameURI n) = [Other Context 6 $ BC.pack n]
 encodeAltName (AltNameIP n) = [Other Context 7 $ n]
 encodeAltName (AltNameXMPP n) =

--- a/crypton-x509/Tests/Tests.hs
+++ b/crypton-x509/Tests/Tests.hs
@@ -18,6 +18,7 @@ import qualified Crypto.PubKey.Ed25519 as Ed25519
 import qualified Crypto.PubKey.Ed448 as Ed448
 import qualified Crypto.PubKey.RSA as RSA
 import Data.ASN1.Types
+import Data.Char (digitToInt)
 import Data.List (nub, sort)
 import Data.X509
 
@@ -251,6 +252,58 @@ property_extension_id e = case extDecode (extEncode e) of
         | v == e -> True
         | otherwise -> error ("expected " ++ show e ++ " got: " ++ show v)
 
+hexBS :: String -> B.ByteString
+hexBS = B.pack . go
+  where
+    go (hi : lo : xs) = fromIntegral (digitToInt hi * 16 + digitToInt lo) : go xs
+    go _ = []
+
+-- GeneralNames with a single directoryName, as encoded by OpenSSL:
+--   openssl req -x509 -newkey ed25519 \
+--     -subj "/CN=Vector Test" -addext "subjectAltName=dirName:dir_sect"
+--   with [dir_sect] C = JP, O = Example Org, CN = Directory Name Test
+-- The directoryName [4] tag is constructed (0xA4) because Name is a CHOICE,
+-- making the context tag EXPLICIT (RFC 5280 4.2.1.6 and appendix A.2).
+opensslDirNameSAN :: B.ByteString
+opensslDirNameSAN =
+    hexBS $
+        "3045A4433041310B3009060355040613024A5031143012060355040A0C0B"
+            ++ "4578616D706C65204F7267311C301A06035504030C134469726563746F72"
+            ++ "79204E616D652054657374"
+
+-- The same GeneralNames with directoryName under a primitive [4] tag (0x84),
+-- as produced by crypton-x509 1.9.1; still accepted when decoding for
+-- backward compatibility.
+legacyDirNameSAN :: B.ByteString
+legacyDirNameSAN =
+    hexBS $
+        "304584433041310B3009060355040613024A5031143012060355040A0C0B"
+            ++ "4578616D706C65204F7267311C301A06035504030C134469726563746F72"
+            ++ "79204E616D652054657374"
+
+dirNameDN :: DistinguishedName
+dirNameDN =
+    DistinguishedName
+        [ ([2, 5, 4, 6], asn1CharacterString Printable "JP")
+        , ([2, 5, 4, 10], asn1CharacterString UTF8 "Example Org")
+        , ([2, 5, 4, 3], asn1CharacterString UTF8 "Directory Name Test")
+        ]
+
+dirNameSAN :: ExtSubjectAltName
+dirNameSAN = ExtSubjectAltName [AltNameDN dirNameDN]
+
+case_dirname_decode_openssl :: Bool
+case_dirname_decode_openssl =
+    extDecodeBs opensslDirNameSAN == Right dirNameSAN
+
+case_dirname_encode_constructed :: Bool
+case_dirname_encode_constructed =
+    extEncodeBs dirNameSAN == opensslDirNameSAN
+
+case_dirname_decode_legacy_primitive :: Bool
+case_dirname_decode_legacy_primitive =
+    extDecodeBs legacyDirNameSAN == Right dirNameSAN
+
 main =
     defaultMain $
         testGroup
@@ -268,6 +321,18 @@ main =
                     , testProperty
                         "extended-key-usage"
                         (property_extension_id :: ExtExtendedKeyUsage -> Bool)
+                    ]
+                , testGroup
+                    "general-name-directoryname"
+                    [ testProperty
+                        "decodes-openssl-constructed"
+                        case_dirname_decode_openssl
+                    , testProperty
+                        "encodes-constructed"
+                        case_dirname_encode_constructed
+                    , testProperty
+                        "decodes-legacy-primitive"
+                        case_dirname_decode_legacy_primitive
                     ]
                 , testProperty
                     "extensions"


### PR DESCRIPTION

`GeneralName.directoryName` (`AltNameDN`) was encoded under a primitive `[4]` tag with nested DER. The `[4]` tag is effectively EXPLICIT — `Name` is an untagged CHOICE, which X.680 does not allow to be implicitly tagged — so it must be encoded in constructed form. As a result, the subjectAltName of a certificate produced by OpenSSL could not be read (the certificate itself still parses, since extensions are stored raw, but `extensionGetE` fails on the SAN), and conversely OpenSSL does not interpret a directoryName written in the primitive form: its `x509 -text` output falls back to a raw dump instead of `DirName:...`.

Encoding now emits the constructed form, byte-identical to OpenSSL output. Decoding accepts both the constructed form and the previous primitive form, keeping backward compatibility with data written by crypton-x509 1.9.1.

This fix is a prerequisite for the RFC 5755 attribute certificate support discussed in #28 — RFC 5755 Section 4.2.3 requires the AC issuer to "contain a non-empty distinguished name in the directoryName field" — but is useful independently. Since it changes the bytes produced for `AltNameDN` (first released in crypton-x509 1.9.1), I am happy to include a version bump if you consider the change breaking.

## Details

ASN.1:

```
GeneralName ::= CHOICE {
    ...
    directoryName  [4]  Name,
    ... }
```

`GeneralName` is defined in RFC 5280 Section 4.2.1.6. `Name` (RFC 5280 Section 4.1.2.4) is itself an untagged CHOICE, and under the ASN.1 tagging rules (ITU-T X.680) a tag applied to an untagged CHOICE is explicit; an explicitly tagged value is encoded in constructed form (ITU-T X.690). The `[4]` tag on directoryName is therefore constructed (tag byte `0xA4`), wrapping the complete `Name` SEQUENCE — the OpenSSL output below confirms this. `AltNameDN` encoded a primitive `[4]` (tag byte `0x84`) containing nested DER; OpenSSL does not produce that form and, as shown below, does not interpret it.

The test vector was produced with OpenSSL (3.6.2 on macOS 26.5/arm64). To reproduce, generate a certificate with a directoryName SAN and extract the extension value:

```console
$ cat dirname-san.cnf
[req]
distinguished_name = dn
prompt = no
[dn]
CN = Vector Test
[v3_ext]
subjectAltName = dirName:dir_sect
[dir_sect]
C = JP
O = Example Org
CN = Directory Name Test

$ openssl req -x509 -newkey ed25519 -nodes -keyout key.pem -out cert.pem \
    -days 3650 -config dirname-san.cnf -extensions v3_ext
$ openssl asn1parse -in cert.pem
...
  172:d=5  hl=2 l=   3 prim: OBJECT            :X509v3 Subject Alternative Name
  177:d=5  hl=2 l=  71 prim: OCTET STRING      [HEX DUMP]:3045A4433041310B...
```

The OCTET STRING content is the GeneralNames encoding and is used verbatim as the test vector:

```
30 45 A4 43 30 41 ...    SEQUENCE { [4] constructed { Name SEQUENCE ... } }
      ^^
      constructed [4] (0xA4), not primitive (0x84)
```

Before this change, reading the SAN from that certificate failed with `GeneralNames: not coping with unknown stream Start (Container Context 4)`, while the certificate itself still parsed (extensions are stored raw). The new test suite includes this exact vector; the new encoder output is byte-identical to OpenSSL's.

The impact is not limited to the directoryName entry itself. GeneralNames is parsed as a whole, so a SAN mixing other name forms with a directoryName was entirely unreadable: with an OpenSSL certificate carrying `DNS:example.com, IP:192.0.2.1, email:admin@example.com, dirName:...`, `extensionGetE` failed with the same error before this change, and returns all four entries after it. Name forms in a SAN without a directoryName are unaffected by this change (their encodings are untouched).

The name constraints support added in #30 uses the same GeneralName parser for `GeneralSubtree`. An OpenSSL-generated CA certificate with a critical `nameConstraints = permitted;dirName:...` extension — the form used for technically constrained subordinate CAs (see golang/go#15196 for the same requirement discussed for Go's crypto/x509) — could not be read either: `extensionGetE` for `ExtNameConstraints` failed with the same error before this change, and returns the `GeneralSubtree` with its directoryName base after it.

The reverse direction fails as well: flipping that tag byte from `A4` to `84` in the certificate — the form the previous encoder produced — leaves OpenSSL unable to interpret the name. `openssl x509 -text` then prints the SAN as a raw byte dump instead of `DirName:/C=JP/O=Example Org/CN=Directory Name Test`.

Decoding accepts both the constructed form and the previous primitive form, keeping backward compatibility with data written by crypton-x509 1.9.1.

## Testing

- New vector tests: decoding an OpenSSL-generated directoryName SAN (fails before this change), byte-identical re-encoding against the same vector, and decoding of the legacy primitive form (guards backward compatibility).
- All existing tests pass (`cabal test` for crypton-x509 and crypton-x509-validation).
- Formatted with the repository's `fourmolu.yaml` (no diff under `fourmolu --mode check`).
